### PR TITLE
added chai-backbone plugin

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -109,8 +109,20 @@ module.exports = [
     , tags: [ 'changes', 'when' ]
     , pkg: 'https://raw.github.com/matthijsgroen/chai-changes/master/package.json'
     , markdown: 'https://raw.github.com/matthijsgroen/chai-changes/master/README.md'
-    , node: false
+    , node: true
     , browser:
       { 'chai-changes.js': 'https://raw.github.com/matthijsgroen/chai-changes/master/chai-changes.js' }
+    }
+
+  , { name: 'Chai Backbone'
+    , desc: 'Common Backbone assertions'
+    , url: 'chai-backbone'
+    , link: 'https://github.com/matthijsgroen/chai-backbone'
+    , tags: [ 'backbone' ]
+    , pkg: 'https://raw.github.com/matthijsgroen/chai-backbone/master/package.json'
+    , markdown: 'https://raw.github.com/matthijsgroen/chai-backbone/master/README.md'
+    , node: true
+    , browser:
+      { 'chai-backbone.js': 'https://raw.github.com/matthijsgroen/chai-backbone/master/chai-backbone.js' }
     }
 ];


### PR DESCRIPTION
I extracted the backbone matchers from the chai-backbone-rails gem. It is now a node package and is addable as plugin to the chai framework. It has a dependency to the chai-changes plugin (as indicated in the package.json)
