### PR TITLE
Added chai-json-schema to plugins.js

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -163,6 +163,7 @@ module.exports = [
     , tags: [ 'objects', 'array' ]
     , pkg: 'https://raw.github.com/Bartvds/chai-json-schema/master/package.json'
     , markdown: 'https://raw.github.com/Bartvds/chai-json-schema/master/README.md'
-    , browser: true
-  }
+    , browser:
+      { 'chai-json-schema.js': 'https://raw.github.com/Bartvds/chai-json-schema/master/index.js' }
+    }
 ];


### PR DESCRIPTION
My json-schema plugin has reached a usable state so it's time to publish it.

It was tricky with reporting useful info on error but I settled to use multiple lines in the message (the jsonpointer's can get very long).

How does updating the readme.md work? What triggers the site to pull the content?
