### PR TITLE
Add chai-webdriver to homepage

### DIFF
--- a/data/index.md
+++ b/data/index.md
@@ -3,10 +3,9 @@
   weight: 0
 ---
 
-Extend Chai with assertions for the Sinon.JS mocking framework.
+Create expressive integration tests with chai and [selenium-webdriver](https://npmjs.org/package/selenium-webdriver).
 
-    var listener = sinon.spy();
-    eventEmitter.on('event', listener);
-    eventEmitter.emit('event', 'chai', 'tea');
-    listener.should.have.been.calledWith('chai', 'tea');
-    listener.should.have.been.calledOnce;
+    chai.use(chaiWebdriver(driver));
+    driver.get('http://chaijs.com/');
+    expect('nav h1').dom.to.contain.text('Chai');
+    expect('#node .button').dom.to.have.style('float', 'left');

--- a/template/index.jade
+++ b/template/index.jade
@@ -94,11 +94,11 @@ block content
       article#plugin-featured.grid_6.plugin-box.contrast
         .plugin-title
           h2.plain.accent-wrap
-            span.accented Sinon—Chai
+            span.accented chai-webdriver
               span.faccentl
               span.faccentr
           .action-button
-            a(href=site.ghbaseurl + '/plugins/sinon-chai') Learn More &amp; Install
+            a(href=site.ghbaseurl + '/plugins/chai-webdriver') Learn More &amp; Install
               span.arrow &rarr;
         .wrap
           h3.fancy Featured Plugin


### PR DESCRIPTION
This would add [chai-webdriver](/goodeggs/chai-webdriver) as the featured plugin on the homepage, taking the place of the venerable Sinon-chai. Wrote some arbitrary sample code that shows the power of the plugin :)

This fixes goodeggs/chai-webdriver#8. Thanks @logicalparadox!
