### PR TITLE
Typo fix in index.html

### DIFF
--- a/out/api/assert/index.html
+++ b/out/api/assert/index.html
@@ -65,7 +65,7 @@
           <div class="wrap">
             <div class="rendered">
               <article><h1 id="assert">Assert</h1>
-<p>The <code>assert</code> style is very similar to node.js&#39; included assert module, which a bit of extra
+<p>The <code>assert</code> style is very similar to node.js&#39; included assert module, with a bit of extra
 sugar. Of the three style options, <code>assert</code> is the only one that is not chainable. Check out 
 the <a href="/guide/comparison">Style Guide</a> for a comparison.</p>
 <h2 id="api-reference">API Reference</h2>


### PR DESCRIPTION
Fixed a minor typo = which should be with.
