### PR TITLE
Fix typos

### DIFF
--- a/data/api/assert.md
+++ b/data/api/assert.md
@@ -5,7 +5,7 @@
 
 # Assert
 
-The `assert` style is very similar to node.js' included assert module, which a bit of extra
+The `assert` style is very similar to node.js' included assert module, with a bit of extra
 sugar. Of the three style options, `assert` is the only one that is not chainable. Check out 
 the [Style Guide](/guide/comparison) for a comparison.
 

--- a/data/guide/helpers.md
+++ b/data/guide/helpers.md
@@ -55,7 +55,7 @@ Model.prototype.get = function (key) {
 };
 ```
 
-Practically speaking, this could be any data model object returned from a 
+Practically speaking, this could be any data model object returned from an
 ORM database in node or constructed from your MVC framework of choice in 
 the browser. 
 

--- a/data/guide/helpers/add_method.md
+++ b/data/guide/helpers/add_method.md
@@ -8,7 +8,7 @@
 
 Though a property is an elegant solution, it is likely not specific enough for 
 the helper we are constructing. As our models have types, it would be beneficial
-to assert our model is of specific type. For this, we need a method.
+to assert that our model is of a specific type. For this, we need a method.
 
 ```javascript
 // goal

--- a/data/guide/helpers/overwrite_language_chain.md
+++ b/data/guide/helpers/overwrite_language_chain.md
@@ -10,7 +10,7 @@ Now that we can successfully add assertions to the language chain,
 we should work on being able to safely overwrite existing assertions,
 such as those from Chai's core or other plugins. 
 
-Chai provides a number of utilties that allow you to overwrite
+Chai provides a number of utilities that allow you to overwrite
 existing behavior of an already existing assertion, but revert to
 the already defined assertion behavior if the subject of the assertion
 does not meet your criteria.

--- a/data/guide/helpers/overwrite_method.md
+++ b/data/guide/helpers/overwrite_method.md
@@ -6,8 +6,8 @@
 
 ### Overwriting Methods
 
-Overwriting methods follow the name structure of overwriting properties.
-For this example we will be returning to our example of asserting Arthurs
+Overwriting methods follow the same structure of overwriting properties.
+For this example we will be returning to our example of asserting Arthur's
 age to be above a minimum threshold.
 
 ```javascript
@@ -49,6 +49,6 @@ Assertion.overwriteMethod('above', function (_super) {
 
 <a href="/api/plugins/#overwriteMethod-section" class="clean-button">View overwriteMethod API</a>
 
-This covers both positive an negative scenarios. No need to transfer flags in this
+This covers both positive and negative scenarios. No need to transfer flags in this
 case as `this.assert` handles that automatically. The same pattern can also be used
 for `below` and `within`. 

--- a/data/guide/plugins/assert.md
+++ b/data/guide/plugins/assert.md
@@ -28,7 +28,7 @@ arthur.assert(
 ```
 
 Chai will check the first argument; if it is `true` then the assertion passed, but if it is `false`
-the assertion failed and the first error message will be thrown as part of an `chai.AssertionError`.
+the assertion failed and the first error message will be thrown as part of a `chai.AssertionError`.
 Conversely, if the language chain was negated, it will consider `false` a pass and `true` a failure. 
 The second error message will be included in the thrown error instead.
 

--- a/out/api/assert/index.html
+++ b/out/api/assert/index.html
@@ -307,8 +307,8 @@ assert.isObject(selection, <span class="string">'tea selection is an object'</sp
                 </ul>
                 <div class="description"><p>Asserts that <code>value</code> is <em>not</em> an object.</p>
 <pre><code><span class="keyword">var</span> selection = <span class="string">'chai'</span>
-assert.isObject(selection, <span class="string">'tea selection is not an object'</span>);
-assert.isObject(<span class="literal">null</span>, <span class="string">'null is not an object'</span>);</code></pre>
+assert.isNotObject(selection, <span class="string">'tea selection is not an object'</span>);
+assert.isNotObject(<span class="literal">null</span>, <span class="string">'null is not an object'</span>);</code></pre>
 </div>
               </div>
               <div id="isArray-section" class="segment">

--- a/out/api/bdd/index.html
+++ b/out/api/bdd/index.html
@@ -77,7 +77,7 @@ Check out the <a href="/guide/styles">Style Guide</a> for a comparison.</p>
                 </ul>
                 <div class="description"><p>The following are provided as chainable getters to
 improve the readability of your assertions. They
-do not provide an testing capability unless they
+do not provide testing capabilities unless they
 have been overwritten by a plugin.</p>
 <p><strong>Chains</strong></p>
 <ul>

--- a/out/guide/helpers/index.html
+++ b/out/guide/helpers/index.html
@@ -122,7 +122,7 @@ Model.prototype.set = <span class="function"><span class="keyword">function</spa
 Model.prototype.get = <span class="function"><span class="keyword">function</span> <span class="params">(key)</span> {</span>
   <span class="keyword">return</span> <span class="keyword">this</span>._attrs[key];
 };</code></pre>
-<p>Practically speaking, this could be any data model object returned from a 
+<p>Practically speaking, this could be any data model object returned from an
 ORM database in node or constructed from your MVC framework of choice in 
 the browser. </p>
 <p>Hopefully our <code>Model</code> class is self explanatory, but as an example,
@@ -164,7 +164,7 @@ we will be calling the methods directly from <code>Assertion</code>.</p>
               <article id="add_method-section"><h3 id="adding-methods">Adding Methods</h3>
 <p>Though a property is an elegant solution, it is likely not specific enough for 
 the helper we are constructing. As our models have types, it would be beneficial
-to assert our model is of specific type. For this, we need a method.</p>
+to assert our model is of a specific type. For this, we need a method.</p>
 <pre><code class="lang-javascript"><span class="comment">// goal</span>
 expect(arthur).to.be.a.model(<span class="string">'person'</span>);
 
@@ -268,7 +268,7 @@ finish up here first...</p>
 <p>Now that we can successfully add assertions to the language chain,
 we should work on being able to safely overwrite existing assertions,
 such as those from Chai&#39;s core or other plugins. </p>
-<p>Chai provides a number of utilties that allow you to overwrite
+<p>Chai provides a number of utilities that allow you to overwrite
 existing behavior of an already existing assertion, but revert to
 the already defined assertion behavior if the subject of the assertion
 does not meet your criteria.</p>
@@ -344,8 +344,8 @@ test suite, so we will provide it with a bit more information.</p>
 expected &#39;dont panic&#39; to [not] be a number</code>. Much more informative! </p>
 </article>
               <article id="overwrite_method-section"><h3 id="overwriting-methods">Overwriting Methods</h3>
-<p>Overwriting methods follow the name structure of overwriting properties.
-For this example we will be returning to our example of asserting Arthurs
+<p>Overwriting methods follow the same structure of overwriting properties.
+For this example we will be returning to our example of asserting Arthur&#39;s
 age to be above a minimum threshold.</p>
 <pre><code class="lang-javascript"><span class="keyword">var</span> arthur = <span class="keyword">new</span> Model(<span class="string">'person'</span>);
 arthur.set(<span class="string">'age'</span>, <span class="number">27</span>);
@@ -378,7 +378,7 @@ so all we have to do is check if that exists.</p>
   };
 });</code></pre>
 <p><a href="/api/plugins/#overwriteMethod-section" class="clean-button">View overwriteMethod API</a></p>
-<p>This covers both positive an negative scenarios. No need to transfer flags in this
+<p>This covers both positive and negative scenarios. No need to transfer flags in this
 case as <code>this.assert</code> handles that automatically. The same pattern can also be used
 for <code>below</code> and <code>within</code>. </p>
 </article>

--- a/out/guide/plugins/index.html
+++ b/out/guide/plugins/index.html
@@ -169,7 +169,7 @@ arthur.assert(
   , <span class="string">"expected #{this} to not be 'Arthur Dent'"</span>
 );</code></pre>
 <p>Chai will check the first argument; if it is <code>true</code> then the assertion passed, but if it is <code>false</code>
-the assertion failed and the first error message will be thrown as part of an <code>chai.AssertionError</code>.
+the assertion failed and the first error message will be thrown as part of a <code>chai.AssertionError</code>.
 Conversely, if the language chain was negated, it will consider <code>false</code> a pass and <code>true</code> a failure. 
 The second error message will be included in the thrown error instead.</p>
 <p>In all, the <code>assert</code> method accepts five arguments:</p>


### PR DESCRIPTION
Fixes #36 and includes #41.

For #36, the relevant passages are getting pulled from [lib/chai/interface/assert.js](https://github.com/chaijs/chai/blob/master/lib/chai/interface/assert.js#L394-L395). I changed that too and will be creating a PR after this one. I tried to edit stuff so that changes apply cleanly without having to edit the generated html file directly but the repos (and their generated files) seem to be out of sync (I'll try to provide more detail if you want me to). I ended up editing the `out/api/assert/index.html` file directly anyway.

I did the same thing for [lib/chai/core/assertions.js](https://github.com/chaijs/chai/blob/master/lib/chai/core/assertions.js#L18) and `out/api/bdd/index.html`.
