### PR TITLE
Make package.json snippet valid json

### DIFF
--- a/data/guide/installation/node.md
+++ b/data/guide/installation/node.md
@@ -15,8 +15,8 @@ This will ensure that you always have the most recent version after running `npm
 which can be especially powerful when paired with a continuous integration tool.
 
 ```javascript
-devDependencies: {
+"devDependencies": {
   "chai": "*",
-  "mocha": "*" // our preference, but you can use any test runner you like
-}
+  "mocha": "*"
+}, "//": "mocha is our preference, but you can use any test runner you like"
 ```


### PR DESCRIPTION
As is, the little package.json snippet will error out with "Failed to parse json" if you insert it.

I understand if you don't want this pull request because the javascript-style comment does look better than the "json comment" (note, using a "//" key is a semi-endorsed way to do comments by npm).

Best
