### PR TITLE
Fix chaijs/chai#141 - make menu links display block

### DIFF
--- a/template/stylus/guide.styl
+++ b/template/stylus/guide.styl
@@ -10,12 +10,13 @@ body.guide
       margin-bottom 10px
       border-radius 3px
       line-height 28px
-      padding 0 6px 0 0 
+      padding 0 6px 0 0
       color #000
       display block
       a.title
         margin-left 34px
         color #000
+        display block
       span.expand
       span.collapse
       span.star


### PR DESCRIPTION
Fixes chaijs/chai#141

@logicalparadox - making the guide links display block means that the majority of the hover state is clickable area. 
### Before

The blue area is the <a> tag and therefore the clickable part
![before](https://cloud.githubusercontent.com/assets/118266/4770956/fca72566-5b89-11e4-86cd-617231f9ea9c.PNG)
### After

The blue area is much more clickable now.
![after](https://cloud.githubusercontent.com/assets/118266/4770957/fcacbc1a-5b89-11e4-9a8e-31386015b42b.PNG)

Tested in Firefox 33, Chrome 40
