### PR TITLE
fix broken link

### DIFF
--- a/out/guide/resources/index.html
+++ b/out/guide/resources/index.html
@@ -86,7 +86,7 @@ directly on Twitter. Chai developers can also be found on Freenode IRC in #letst
 changes to the library are to be made to <code>lib/*</code> and then packaged for the browser using the <code>make</code>
 command.</p>
 <h3 id="testing">Testing</h3>
-<p>Tests are written in <code>exports</code> style on <a href="http://visionmedia.github.com/mocha/">mocha test framework</a>.
+<p>Tests are written in <code>exports</code> style on <a href="http://mochajs.org/">mocha test framework</a>.
 There is a test file for each of the interfaces. The tests for <code>expect</code> and <code>assert</code> must pass in node.js
 and in the browser, whereas the should tests only need to pass on node.js.</p>
 <p>Browsers tests are currently known to pass in Chrome 16 and Firefox 8. Please let me know if you can test


### PR DESCRIPTION
I assume that this is supposed to go to the mochajs.org site; the referenced url is 404.
