### PR TITLE
Fix canonical URL

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,7 +7,7 @@
     <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | markdownify | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
     <link rel='icon' type='image/x-icon' href="{{site.github.url}}/img/favicon.ico">
-    <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.github.url | prepend: site.url }}">
+    <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.url }}">
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="{{site.github.url}}/js/jquery-mousewheel.js"></script>


### PR DESCRIPTION
Since github already overwrites `site.url`, we don't need to prepend `site.github.url`.

> **GitHub Pages overrides the "Site Source" configuration value**, so if you locate your files anywhere other than the root directory, your site may not build correctly.

As you can see, before this PR, we have a duplicate url there:

<img width="529" alt="screen shot 2018-03-14 at 09 02 59" src="https://user-images.githubusercontent.com/6868147/37392615-86a390dc-2766-11e8-9800-ccc6aa4c09a1.png">
