### PR TITLE
Use https for imported Google fonts.

### DIFF
--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -1,4 +1,4 @@
-@import url("http://fonts.googleapis.com/css?family=Lato:300|Redressed");
+@import url("https://fonts.googleapis.com/css?family=Lato:300|Redressed");
 html,
 body,
 div,


### PR DESCRIPTION
I think this'll prevent the following error from showing up in the website's console:

(index):1 Mixed Content: The page at 'https://www.chaijs.com/api/assert/' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=Lato:300|Redressed'. This request has been blocked; the content must be served over HTTPS.