### PR TITLE
Change http to https for Google Font URL

### DIFF
--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -1,4 +1,4 @@
-@import url("http://fonts.googleapis.com/css?family=Lato:300|Redressed");
+@import url("https://fonts.googleapis.com/css?family=Lato:300|Redressed");
 html,
 body,
 div,


### PR DESCRIPTION
Google Chrome blocks any mixed content requests.