### PR TITLE
chore: update doc website footer build status link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -30,7 +30,7 @@
             <ul>
                 <li><a href="https://github.com/chaijs/chai/issues" target="_blank">Issues</a></li>
                 <li><a href="https://groups.google.com/group/chaijs" target="_blank">Google Group</a></li>
-                <li><a href="https://travis-ci.org/#!/chaijs/chai" target="_blank">Build Status</a></li>
+                <li><a href="https://github.com/chaijs/chai/actions" target="_blank">Build Status</a></li>
             </ul>
         </div>
     </section>


### PR DESCRIPTION
Chai use github actions as CI now, so replace travis-ci link width github actions. cc  @keithamus 