### PR TITLE
Ban not maintained fork of sinon-chai

### DIFF
--- a/_scripts/banned_plugins.js
+++ b/_scripts/banned_plugins.js
@@ -3,6 +3,7 @@ module.exports = [
    // Personal forks
   '@cypress/sinon-chai',
   '@slightlytyler/sinon-chai',
+  'chai-sinon',
 
   'chai-51st-state', // Banned for profane language
   'chai2.0-webdriver-promised', // Fork with poor metadata


### PR DESCRIPTION
[`chai-sinon`](https://github.com/michaelgmcd/chai-sinon) is a fork of [`sinon-chai`](https://github.com/domenic/sinon-chai) which intends to be more maintained. However, it hasn't been updated for more than 5 years and has a very low adoption rate ([600 weekly downloads on npm](https://www.npmjs.com/package/chai-sinon) vs [600k for sinon-chai](https://www.npmjs.com/package/sinon-chai)).