### PR TITLE
Fix type in api/plugins.md

### DIFF
--- a/api/plugins.md
+++ b/api/plugins.md
@@ -8,6 +8,6 @@
 # Plugin Utilities
 
 The plugin utilities are for those who want to extend Chai with their own set of
-assertions. The [Code Plugin Concepts]({{site.github.url}}/guide/plugins) and
+assertions. The [Core Plugin Concepts]({{site.github.url}}/guide/plugins) and
 [Building a Helper]({{site.github.url}}/guide/helpers) guide tutorials are a great reference on
 how to get started with your own assertions.


### PR DESCRIPTION
Fixed typo cause the [page name](https://github.com/chaijs/chaijs.github.io/blob/master/_guides/plugins.md#core-plugin-concepts) is 'Co**R**e Plugin Concepts'