### PR TITLE
Add encodeURIComponent in md in build-plugin-pages.js

### DIFF
--- a/_scripts/build-plugin-pages.js
+++ b/_scripts/build-plugin-pages.js
@@ -6,7 +6,7 @@ files.filter(function (file) {
   try {
     var name = file.slice(0, -5);
     var pluginJson = JSON.parse(fs.readFileSync('_data/plugins/' + file, 'utf8'));
-    var contents = '---\nlayout: plugin\npermalink: plugins/' + pluginJson.name + '/\npluginName: ' + pluginJson.name + '\n---\n\n' + pluginJson.readme;
+    var contents = '---\nlayout: plugin\npermalink: plugins/' + encodeURIComponent(pluginJson.name) + '/\npluginName: ' + encodeURIComponent(pluginJson.name) + '\n---\n\n' + pluginJson.readme;
     fs.writeFileSync(__dirname + '/../plugins/' + name + '.md', contents, 'utf8');
     console.log('Wrote', 'plugins/' + name + '.md')
   } catch(e) {


### PR DESCRIPTION
Fixes #212. Encodes `@` and `/` characters to ensure valid YAML in markdown files.