### PR TITLE
docs: update guides to use esm

### DIFF
--- a/_guides/helpers.md
+++ b/_guides/helpers.md
@@ -74,7 +74,7 @@ Hopefully our `Model` class is self explanatory, but as an example,
 here we construct a person object.
 
 ```javascript
-var arthur = new Model('person');
+const arthur = new Model('person');
 arthur.set('name', 'Arthur Dent');
 arthur.set('occupation', 'traveller');
 console.log(arthur.get('name')); // Arthur Dent
@@ -97,7 +97,7 @@ implementation throughout.
 For this example, we want the following test case to pass:
 
 ```javascript
-var arthur = new Model('person');
+const arthur = new Model('person');
 expect(arthur).to.be.a.model;
 ```
 
@@ -141,7 +141,7 @@ expect(arthur).to.be.a.model('person');
 
 // language chain method
 Assertion.addMethod('model', function (type) {
-  var obj = this._obj;
+  const obj = this._obj;
 
   // first, our instanceof check, shortcut
   new Assertion(this._obj).to.be.instanceof(Model);
@@ -176,8 +176,8 @@ To understand when to best use chainable methods we will examine a chainable met
 core.
 
 ```javascript
-var arr = [ 1, 2, 3 ]
-  , obj = { a: 1, b: 2 };
+const arr = [ 1, 2, 3 ];
+const obj = { a: 1, b: 2 };
 
 expect(arr).to.contain(2);
 expect(obj).to.contain.key('a');
@@ -241,7 +241,7 @@ function assertModelAge (n) {
   new Assertion(this._obj).to.be.instanceof(Model);
 
   // make sure we have an age and its a number
-  var age = this._obj.get('age');
+  const age = this._obj.get('age');
   new Assertion(age).to.be.a('number');
 
   // do our comparison
@@ -301,7 +301,7 @@ Let's start out with the basic overwrite utility and a basic assertion.
 ```javascript
 chai.overwriteProperty('ok', function (_super) {
   return function checkModel () {
-    var obj = this._obj;
+    const obj = this._obj;
     if (obj && obj instanceof Model) {
       new Assertion(obj).to.have.deep.property('_attrs.id').a('number');
     } else {
@@ -324,7 +324,7 @@ will serve as the actual assertion.
 With this in place, we can write positive assertions.
 
 ```javascript
-var arthur = new Model('person');
+const arthur = new Model('person');
 arthur.set('id', 42);
 expect(arthur).to.be.ok;
 expect(true).to.be.ok;
@@ -336,7 +336,7 @@ revert to the original behavior. We will, however, run into a bit of
 trouble if we try to negate an `ok` assertion on a model.
 
 ```javascript
-var arthur = new Model('person');
+const arthur = new Model('person');
 arthur.set('id', 'dont panic');
 expect(arthur).to.not.be.ok;
 ```
@@ -355,10 +355,10 @@ property overwrite would look like this.
 ```javascript
 chai.overwriteProperty('ok', function (_super) {
   return function checkModel () {
-    var obj = this._obj;
+    const obj = this._obj;
     if (obj && obj instanceof Model) {
       new Assertion(obj).to.have.deep.property('_attrs.id'); // we always want this
-      var assertId = new Assertion(obj._attrs.id);
+      const assertId = new Assertion(obj._attrs.id);
       utils.transferFlags(this, assertId, false); // false means don't transfer `object` flag
       assertId.is.a('number');
     } else {
@@ -380,7 +380,7 @@ for the wrong type of id attribute, we would get an error message that states
 test suite, so we will provide it with a bit more information.
 
 ```javascript
-var assertId = new Assertion(obj._attrs.id, 'model assert ok id type');
+const assertId = new Assertion(obj._attrs.id, 'model assert ok id type');
 ```
 
 This will change our error message to be a more informative `model assert ok id type:
@@ -393,7 +393,7 @@ For this example we will be returning to our example of asserting Arthur's
 age to be above a minimum threshold.
 
 ```javascript
-var arthur = new Model('person');
+const arthur = new Model('person');
 arthur.set('age', 27);
 expect(arthur).to.have.age.above(17);
 ```
@@ -405,7 +405,7 @@ so all we have to do is check if that exists.
 Assertion.overwriteMethod('above', function (_super) {
   return function assertAge (n) {
     if (utils.flag(this, 'model.age')) {
-      var obj = this._obj;
+      const obj = this._obj;
 
       // first we assert we are actually working with a model
       new Assertion(obj).instanceof(Model);
@@ -414,7 +414,7 @@ Assertion.overwriteMethod('above', function (_super) {
       new Assertion(obj).to.have.deep.property('_attrs.age').a('number');
 
       // now we compare
-      var age = obj.get('age');
+      const age = obj.get('age');
       this.assert(
           age > n
         , "expected #{this} to have an age above #{exp} but got #{act}"

--- a/_guides/plugins.md
+++ b/_guides/plugins.md
@@ -46,7 +46,7 @@ community. A more appropriate pattern for creating helpers is as follows...
 For our helper file: `test/helpers/model.js`
 
 ```javascript
-module.exports = function (chai, utils) {
+export function chaiModel(chai, utils) {
   var Assertion = chai.Assertion;
 
   // your helpers here
@@ -56,9 +56,9 @@ module.exports = function (chai, utils) {
 And, for our actual test: `test/person.js`
 
 ```javascript
-var chai = require('chai')
-  , chaiModel = require('./helpers/model')
-  , expect = chai.expect;
+import * as chai from 'chai';
+import {chaiModel} from './helpers/model.js'
+import {expect} from 'chai';
 
 chai.use(chaiModel);
 ```
@@ -85,9 +85,9 @@ The flag utility is exposed as `utils.flag` from within our `use` function. It c
 as either a getter or a setter, depending on the number of arguments passed to it.
 
 ```javascript
-var myAssert = new Assertion(obj);
+const myAssert = new Assertion(obj);
 utils.flag(myAssert, 'owner', 'me'); // sets key `owner` to `me`
-var owner = utils.flag(myAssert, 'owner'); // get key `owner', returns value
+const owner = utils.flag(myAssert, 'owner'); // get key `owner', returns value
 ```
 
 ### object flag
@@ -96,15 +96,15 @@ The most important of Chai's reserved flags is the `object` flag. This is the su
 of an assertion.
 
 ```javascript
-var myAssert = new Assertion('Arthur Dent');
-var obj = flag(myAssert, 'object'); // obj === 'Arthur Dent';
+const myAssert = new Assertion('Arthur Dent');
+const obj = flag(myAssert, 'object'); // obj === 'Arthur Dent';
 ```
 
 This flag is so often used that a shortcut was provided as the `_obj` property of a
 constructed assertion.
 
 ```javascript
-var obj = myAssert._obj; // obj === `Arthur Dent`
+const obj = myAssert._obj; // obj === `Arthur Dent`
 ```
 
 The following flags are used by Chai's core assertions. Side effects may occur should you
@@ -135,7 +135,7 @@ negated or not.
 To begin, we will construct Arthur again, then we can assert that he is who he says he is.
 
 ```javascript
-var arthur = new Assertion('Arthur Dent');
+const arthur = new Assertion('Arthur Dent');
 
 arthur.assert(
     arthur._obj === 'Arthur Dent'

--- a/_guides/styles.md
+++ b/_guides/styles.md
@@ -28,9 +28,10 @@ node.js. This assert module, however, provides several additional
 tests and is browser compatible.
 
 ```js
-var assert = require('chai').assert
-  , foo = 'bar'
-  , beverages = { tea: [ 'chai', 'matcha', 'oolong' ] };
+import {assert} from 'chai';
+
+const foo = 'bar';
+const beverages = { tea: [ 'chai', 'matcha', 'oolong' ] };
 
 assert.typeOf(foo, 'string'); // without optional message
 assert.typeOf(foo, 'string', 'foo is a string'); // with optional message
@@ -59,9 +60,10 @@ The BDD style is exposed through `expect` or `should` interfaces. In both
 scenarios, you chain together natural language assertions.
 
 ```js
-var expect = require('chai').expect
-  , foo = 'bar'
-  , beverages = { tea: [ 'chai', 'matcha', 'oolong' ] };
+import {expect} from 'chai';
+
+const foo = 'bar';
+const beverages = { tea: [ 'chai', 'matcha', 'oolong' ] };
 
 expect(foo).to.be.a('string');
 expect(foo).to.equal('bar');
@@ -73,7 +75,7 @@ Expect also allows you to include arbitrary messages to prepend to any failed
 assertions that might occur.
 
 ```js
-var answer = 43;
+const answer = 43;
 
 // AssertionError: expected 43 to equal 42.
 expect(answer).to.equal(42);
@@ -94,9 +96,12 @@ property to start your chain. This style has some issues when used with Internet
 Explorer, so be aware of browser compatibility.
 
 ```js
-var should = require('chai').should() //actually call the function
-  , foo = 'bar'
-  , beverages = { tea: [ 'chai', 'matcha', 'oolong' ] };
+import {should} from 'chai';
+
+should(); //actually call the function
+
+const foo = 'bar';
+const beverages = { tea: [ 'chai', 'matcha', 'oolong' ] };
 
 foo.should.be.a('string');
 foo.should.equal('bar');
@@ -111,9 +116,10 @@ First of all, notice that the `expect` require is just a reference to the
 being executed.
 
 ```js
-var chai = require('chai')
-  , expect = chai.expect
-  , should = chai.should();
+import * as chai from 'chai';
+
+const {expect} = chai;
+const should = chai.should();
 ```
 
 The `expect` interface provides a function as a starting point for chaining
@@ -143,7 +149,10 @@ with a `should` chain starter. As such, the appropriate few assertions
 for this scenario are as follows:
 
 ```js
-var should = require('chai').should();
+import {should as loadShould} from 'chai';
+
+const should = loadShould();
+
 db.get(1234, function (err, doc) {
   should.not.exist(err);
   should.exist(doc);
@@ -168,7 +177,7 @@ statement – it has to go on its own line, which looks a little
 verbose:
 
 ```js
-import chai from 'chai';
+import * as chai from 'chai';
 chai.should();
 ```
 

--- a/_guides/using-chai-with-esm-and-plugins.md
+++ b/_guides/using-chai-with-esm-and-plugins.md
@@ -27,8 +27,8 @@ import { expect } from 'chai';
 Chai plugins can extend Chai's capabilities. To use a plugin, you first need to install it, then use the `use` method to load it. Here's how to use the `chai-http` plugin as an example:
 
 ```javascript
-import chai from 'chai';
-import { request }, chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { request, default as chaiHttp } from 'chai-http';
 
 chai.use(chaiHttp);
 
@@ -40,8 +40,10 @@ chai.use(chaiHttp);
 Here's an example of using `chai-http` to test an HTTP GET request:
 
 ```javascript
-import chai, { expect } from 'chai';
-import { request }, chaiHttp from 'chai-http';
+import * as chai from 'chai';
+import { request, default as chaiHttp } from 'chai-http';
+
+const {expect} = chai;
 
 chai.use(chaiHttp);
 


### PR DESCRIPTION
Updates the guides to use ES module imports and `const` rather than `var`.

cc @koddsson 

Fixes chaijs/chai#1654

Although I've updated the guides here, almost all of the docs in `plugins/` are wrong (CJS). but there's so many, I think we should do a bit at a time and may even be able to remove some of the ancient ones