### PR TITLE
Removed the non-existing heading from sidebar

### DIFF
--- a/_guides/installation.md
+++ b/_guides/installation.md
@@ -7,7 +7,6 @@
   headings:
     - Node.js
     - Browser
-    - Other Platforms
 ---
 
 # Installation


### PR DESCRIPTION
The sidebar of the Guide pages of "Installation" contains a heading titled "Other Platforms".
<img width="273" height="532" alt="image" src="https://github.com/user-attachments/assets/08513b0d-cab3-4ea2-aca6-0c2f43bf82e1" />

This link of this header is broken and there is no content corresponding to this heading.
Hence this heading should be removed.

This PR aims to improvise the Website documentation by removing the concerned broken heading link.